### PR TITLE
Expand the requirements so JRuby can resolve them from jar files.

### DIFF
--- a/lib/arr-pm/file/header.rb
+++ b/lib/arr-pm/file/header.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "..", "namespace")
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "namespace"))
 require File.join(File.dirname(__FILE__), "tag")
 require "cabin"
 

--- a/lib/arr-pm/file/lead.rb
+++ b/lib/arr-pm/file/lead.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "..", "namespace")
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "namespace"))
 require "cabin"
 
 class RPM::File::Lead

--- a/lib/arr-pm/file/tag.rb
+++ b/lib/arr-pm/file/tag.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), "..", "namespace")
+require File.expand_path(File.join(File.dirname(__FILE__), "..", "namespace"))
 require "cabin"
 
 class RPM::File::Tag


### PR DESCRIPTION
So JRuby is failing to relatively resolve namespace script. I submitted this as a bug with JRuby cause I think its a bug there. But this is a work around.
