### PR TITLE
Fixed config_files crashing when no files are in rpm

### DIFF
--- a/lib/arr-pm/file.rb
+++ b/lib/arr-pm/file.rb
@@ -181,7 +181,7 @@ class RPM::File
       # The :fileflags (and other :file... tags) are an array, in order of
       # files in the rpm payload, we want a list of paths of config files.
       results << files[i] if mask?(flag, FLAG_CONFIG_FILE)
-    end
+    end unless tags[:fileflags].nil? # This can be null if there is no file stored in the rpm.
     return results
   end # def config_files
 


### PR DESCRIPTION
When an rpm is read from arr-pm, `#config_files` can raise an error due to the `tags[:fileflags]` array being nil.
This makes it return `[]`.
