### PR TITLE
Fixes hang in cpio command due to a full read buffer

### DIFF
--- a/arr-pm.gemspec
+++ b/arr-pm.gemspec
@@ -2,7 +2,7 @@ Gem::Specification.new do |spec|
   files = %x{git ls-files}.split("\n")
 
   spec.name = "arr-pm"
-  spec.version = "0.0.10"
+  spec.version = "0.0.11"
   spec.summary = "RPM reader and writer library"
   spec.description = "This library allows to you to read and write rpm " \
     "packages. Written in pure ruby because librpm is not available " \


### PR DESCRIPTION
Fixes issue #8 also related to dnbert/prm#52...caused by read buffer being too full to allow writes therefore blocking write.

This can cause large rpm files to permanently hang the prm command 