### PR TITLE
Only attempt extraction if a known payload compressor is used.

### DIFF
--- a/arr-pm.gemspec
+++ b/arr-pm.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "flores", ">0"
   spec.add_development_dependency "rspec", ">3.0.0"
+  spec.add_development_dependency "stud", ">=0.0.23"
+  spec.add_development_dependency "insist", ">=1.0.0"
   #spec.homepage = "..."
 end
 

--- a/spec/rpm/file_spec.rb
+++ b/spec/rpm/file_spec.rb
@@ -1,11 +1,14 @@
 # encoding: utf-8
 
 require "arr-pm/file"
+require "stud/temporary"
+require "insist"
 
 describe ::RPM::File do
+  subject { described_class.new(path) }
+
   context "with a known good rpm" do
     let(:path) { File.join(File.dirname(__FILE__), "../fixtures/pagure-mirror-5.13.2-5.fc35.noarch.rpm") }
-    subject { described_class.new(path) }
 
     context "#files" do
       let(:files) { [
@@ -16,6 +19,38 @@ describe ::RPM::File do
 
       it "should have the correct list of files" do
         expect(subject.files).to eq(files)
+      end
+    end
+  end
+
+  context "#extract" do
+    # This RPM should be correctly built, but we will modify the tags at runtime to force an error.
+    let(:path) { File.join(File.dirname(__FILE__), "../fixtures/example-1.0-1.x86_64.rpm") }
+    let(:dir) { dir = Stud::Temporary.directory }
+
+    after do
+      FileUtils.rm_rf(dir)
+    end
+
+    context "with an invalid payloadcompressor" do
+      before do
+        subject.tags[:payloadcompressor] = "some invalid | string"
+      end
+
+      it "should raise an error" do
+        insist { subject.extract(dir) }.raises(RuntimeError)
+      end
+    end
+
+    [ "gzip", "bzip2", "xz", "lzma", "zstd" ].each do |name|
+      context "with a '#{name}' payloadcompressor" do
+        before do
+          subject.tags[:payloadcompressor] = name
+        end
+
+        it "should succeed" do
+          reject { subject.extract(dir) }.raises(RuntimeError)
+        end
       end
     end
   end


### PR DESCRIPTION
This change is to improve safety primarily to reject malicious rpms with a custom PAYLOADCOMPRESSOR tag causing arr-pm to execute arbitrary code.

The security issue was reported by Joern Schneeweisz.

An alternate implementation could be to do what rpm does in its rpmio library which is to use the C implementations of various compressor libraries. However, doing this in Ruby can cause problems because it's not always possible to compile C Ruby extensions or even install Ruby's FFI library.

Test coverage checks for accepting known payload compressors and also rejecting unknown compressor values.

Context: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/97602