### PR TITLE
Generate the list of files by merging the basenames, dirindexes, and dirnames tags

### DIFF
--- a/lib/arr-pm/file.rb
+++ b/lib/arr-pm/file.rb
@@ -211,9 +211,10 @@ class RPM::File
     # RPM stores the file metadata split across multiple tags.
     # A single path's filename (with no directories) is stored in the "basename" tag.
     # The directory a file lives in is stored in the "dirnames" tag
+    # We can find out what directory a file is in using the "dirindexes" tag.
     #
     # We can join each entry of dirnames and basenames to make the full filename.
-    return tags[:dirnames].zip(tags[:basenames]).map &File.method(:join)
+    return tags[:basenames].zip(tags[:dirindexes]).map { |name, i| File.join(tags[:dirnames][i], name) }
   end # def files
 
   def mask?(value, mask)


### PR DESCRIPTION
The prior method assumed basenames and dirnames had a 1:1 relationship, but the fpm test suite found this to be an incorrect assumption.

Best I can tell, the relationship is:

* basenames has the filenames
* dirindexes is a list of array index offsets for a given file into the dirnames tag.

For example, it seems like the first entry in basenames has a directory path of dirnames[dirindexes[0]]