### PR TITLE
Remove cabin dependency

### DIFF
--- a/arr-pm.gemspec
+++ b/arr-pm.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |spec|
     "on all systems"
   spec.license = "Apache 2"
 
-  spec.add_dependency "cabin", ">0" # for logging. apache 2 license
   spec.files = files
   spec.require_paths << "lib"
   spec.bindir = "bin"

--- a/lib/arr-pm/file/header.rb
+++ b/lib/arr-pm/file/header.rb
@@ -1,9 +1,7 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "namespace"))
 require File.join(File.dirname(__FILE__), "tag")
-require "cabin"
 
 class RPM::File::Header
-  include Cabin::Inspectable
   attr_reader :tags
   attr_reader :length
 

--- a/lib/arr-pm/file/lead.rb
+++ b/lib/arr-pm/file/lead.rb
@@ -1,8 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "namespace"))
-require "cabin"
 
 class RPM::File::Lead
-  include Cabin::Inspectable
 
   #struct rpmlead {
   attr_accessor :magic #unsigned char magic[4];

--- a/lib/arr-pm/file/tag.rb
+++ b/lib/arr-pm/file/tag.rb
@@ -1,8 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), "..", "namespace"))
-require "cabin"
 
 class RPM::File::Tag
-  include Cabin::Inspectable
 
   attr_accessor :tag
   attr_accessor :type


### PR DESCRIPTION
Cabin is a logging library that is otherwise unused by arr-pm.

A few parts of arr-pm were doing `include Cabin::Inspectable` to aid in debugging, but I think it's safe to remove.

I also ran fpm's test suite with this patch (removing cabin from arr-pm) and it passes. I therefore think this change is safe.

The result is that now arr-pm has no external runtime dependencies :)